### PR TITLE
Install liblz4-tool, required for compressing newer kernel images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG USERNAME=kernel-builder
 RUN apt-get update && \
     apt-get install -y \
     git fakeroot build-essential ncurses-dev xz-utils libssl-dev bc wget \
-    flex curl bison rsync kmod cpio libelf-dev
+    flex curl bison rsync kmod cpio libelf-dev liblz4-tool
 
 RUN apt-get install -y python3 python3-requests
 RUN apt-get install -y gnupg


### PR DESCRIPTION
Adds the `liblz4-tool` package to the first RUN command of your Dockerfile. Liblz4-tool is required to allow for lz4 compression of newer kernels (https://lists.ubuntu.com/archives/ubuntu-devel/2019-June/040726.html); else, you run into a little bit of 

```
LZ4     arch/x86/boot/compressed/vmlinux.bin.lz4
/bin/sh: 1: lz4c: not found
make[5]: *** [arch/x86/boot/compressed/Makefile:149: arch/x86/boot/compressed/vmlinux.bin.lz4] Error 127
make[5]: *** Deleting file 'arch/x86/boot/compressed/vmlinux.bin.lz4'
make[5]: *** Waiting for unfinished jobs....
make[4]: *** [arch/x86/boot/Makefile:115: arch/x86/boot/compressed/vmlinux] Error 2
make[3]: *** [arch/x86/Makefile:263: bzImage] Error 2
make[3]: *** Waiting for unfinished jobs....
```
 
Thanks for getting me up and running with this awesome tool!